### PR TITLE
feat: add bubble bar adaptive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ BubbleBarView(selectedTab: $selectedTab) {
 .bubbleBarViewTransition(.easeInOut)       // Custom animation for view transitions
 .showBubbleBarLabels(true)                 // Show/hide labels
 .bubbleBarSize(CGSize(width: 350, height: 60))  // Optional fixed size
+.bubbleBarAdaptiveItemsWidth(false)        // adaptively adjust the bubble bar width of the bubble bar items's width
 .bubbleBarShape(RoundedRectangle(cornerRadius: 20))  // Container shape
 .bubbleBarItemShape(Capsule())             // Selected item shape
 .bubbleBarItemEqualSizing(true)            // Equal width items

--- a/Sources/BubbleBar/Style/BubbleBar.Configuration.swift
+++ b/Sources/BubbleBar/Style/BubbleBar.Configuration.swift
@@ -12,6 +12,7 @@ extension BubbleBar {
         public var viewTransition: AnyTransition
         public var showLabels: Bool
         public var size: CGSize?
+        public var adaptiveItemsWidth: Bool
         public var shape: AnyShape
         public var itemShape: AnyShape
         public var padding: EdgeInsets
@@ -45,6 +46,7 @@ extension BubbleBar {
             viewTransition: AnyTransition = .opacity,
             showLabels: Bool = true,
             size: CGSize? = nil,
+            adaptiveItemsWidth: Bool = false,
             shape: AnyShape = AnyShape(RoundedRectangle(cornerRadius: 28)),
             itemShape: AnyShape = AnyShape(RoundedRectangle(cornerRadius: 24)),
             padding: EdgeInsets = EdgeInsets(top: 6, leading: 6, bottom: 6, trailing: 6),
@@ -70,6 +72,7 @@ extension BubbleBar {
             self.viewTransition = viewTransition
             self.showLabels = showLabels
             self.size = size
+            self.adaptiveItemsWidth = adaptiveItemsWidth
             self.shape = shape
             self.itemShape = itemShape
             self.padding = padding
@@ -104,6 +107,7 @@ extension BubbleBar {
             viewTransition: AnyTransition = .opacity,
             showLabels: Bool = true,
             size: CGSize? = nil,
+            adaptiveItemsWidth: Bool = false,
             shape: AnyShape = AnyShape(RoundedRectangle(cornerRadius: 28)),
             itemShape: AnyShape = AnyShape(RoundedRectangle(cornerRadius: 24)),
             padding: EdgeInsets = EdgeInsets(top: 6, leading: 6, bottom: 6, trailing: 6),
@@ -136,6 +140,7 @@ extension BubbleBar {
                 viewTransition: viewTransition,
                 showLabels: showLabels,
                 size: size,
+                adaptiveItemsWidth: adaptiveItemsWidth,
                 shape: shape,
                 itemShape: itemShape,
                 padding: padding,

--- a/Sources/BubbleBar/Views/BubbleBar.swift
+++ b/Sources/BubbleBar/Views/BubbleBar.swift
@@ -218,6 +218,15 @@ public extension View {
             config.size = size
         }
     }
+
+    /// adaptively adjust the bubble bar width of the bubble bar items's width
+    /// - Parameter enabled: Whether to enable equal width for all items's total width
+    /// - Returns: A view with the modified bubble bar item width
+    func bubbleBarAdaptiveItemsWidth(_ enabled: Bool) -> some View {
+        transformEnvironment(\.bubbleBarConfiguration) { config in
+            config.adaptiveItemsWidth = enabled
+        }
+    }
     
     /// Sets the shape of the bubble bar container.
     /// - Parameter shape: The shape to apply to the container

--- a/Sources/BubbleBar/Views/Internal Components/TabBarContainer.swift
+++ b/Sources/BubbleBar/Views/Internal Components/TabBarContainer.swift
@@ -28,7 +28,7 @@ extension BubbleBar {
                     maxHeight: configuration.size?.height ?? 64,
                     alignment: .center
                 )
-                .fixedSize(horizontal: false, vertical: true)
+                .fixedSize(horizontal: configuration.adaptiveItemsWidth && configuration.size == nil, vertical: true)
                 .background {
                     if configuration.isGlass {
                         glassBackground


### PR DESCRIPTION
If the number of items is less than five, according to the original logic, there will be a lot of blank space. However, if you use bubbleBarSize with a fixed size, you need to write some additional size calculation logic, which I personally feel is not very suitable. Therefore, I want to add a modifier that automatically adjusts the total size of the items. If you have any suggestions for this PR, I would appreciate your advice.

`.bubbleBarAdaptiveItemsWidth(false)`
<img width="418" alt="image" src="https://github.com/user-attachments/assets/4cfc8c27-333b-4fb1-b4eb-d5312854bd56" />

`.bubbleBarAdaptiveItemsWidth(true)`
<img width="418" alt="image" src="https://github.com/user-attachments/assets/56faca81-96dd-48cb-96bf-120789195f18" />

